### PR TITLE
修复anki_server运行时异常和PID信息不实引起的monit对anki_server监控失效的问题

### DIFF
--- a/script_bootloader/usr/anki_server/bin/anki_server_enable.service
+++ b/script_bootloader/usr/anki_server/bin/anki_server_enable.service
@@ -41,9 +41,8 @@ logger -st "($(basename $0))" $$ "*--------- ${SERVICE_NAME}_${SERVICE_FUNCTION}
 #
 ########## ENABLE ANKI-SERVER ##########
 #
+export LC_ALL="en_US.UTF-8"
 nohup ankiserverctl.py start ${PRIVATE_ETC}/production.ini &> /dev/null &
-PID=$(echo $!)
-echo ${PID} > /var/run/anki_server.pid
 #
 ########## END ##########
 #

--- a/script_bootloader/usr/anki_server/etc/monit.d/anki_server
+++ b/script_bootloader/usr/anki_server/etc/monit.d/anki_server
@@ -1,4 +1,4 @@
-check process ANKI_SERVER with pidfile '/var/run/anki_server.pid'
+check process ANKI_SERVER with matching '[python*serve] production.ini'
     start program = "/opt/script_bootloader/usr/anki_server/bin/anki_server_enable.service"
     stop program = "/opt/script_bootloader/usr/anki_server/bin/anki_server_disable.service"
     if does not exist then restart


### PR DESCRIPTION
TESTED: RT-AC68U
固件： 384.10_2
PID=$(echo $!)获取到的应该是nohup所起后台任务时候的PID，后台任务启动成功后nohup应该退出了。
使用ps | grep 加上当前服务任务命令行特有参数信息可以获取当前所起的任务的后台进程的PID，例：PID=$(ps | grep '[python*serve] production.ini'|awk '{print $1}')，但需要在执行nohup后延时获取。只是我测试了多次该脚本由monit启动时却获取不了PID，终端手工启动却可以。配合修改monit.d/anki_server文件可以解决monit监控anki_server的问题。
原则上，针对类似启动python脚本服务的情况应该都适应，我只搭建了ANKI_SERVER，可以解决启动异常和运行监控问题，暂时没用到其它服务故对其它脚本未作测试。
前面失误提交到SCRIPTS-BOOTLOADER-FOR-ASUS-ROUTER-ADDONS中去了，请忽视。